### PR TITLE
Make usable again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ hs_err_pid*
 .project
 bot-keys.jks
 .settings
+owner-trusted-certs.jks

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /target/
+.classpath
+.project
+bot-keys.jks
+.settings

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # won-randomsimulatorbot
-RandomSimulatorBot description tbd
+
+This Bot eternally creates new Atoms using TTL files in a specified folder as templates. If contacted with Hints or Connects, it randomly establishes some connections while denying others. It will, at random either respond to incoming messages in these connections or close them again. All its actions have a random delay within a few seconds.
+
+## Running the bot
+
+### Prerequisites
+
+- [Java 8 JDK](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or higher installed (openJDK 12 is currently not supported and won't work)
+- Maven framework set up
+
+### On the command line
+
+```
+cd won-randomsimulatorbot
+export WON_NODE_URI="https://hackathonnode.matchat.org/won"
+export ATOM_TEMPLATE_DIR="src/main/resources/atom-templates"
+mvn clean package
+java -jar target/bot.jar
+```
+Note: this only works if you have the bouncycastle libraries installed for your java installation. If you don't have that, the following line will start the bot 
+
+```
+#(assuming you ran the code above, so you have the environment variables set)
+java -cp "target/bot.jar;target/bouncycastle-libs/bcpkix-jdk15on-1.52.jar;target/bouncycastle-libs/bcprov-jdk15on-1.52.jar" won.bot.randomsimulatorbot.RandomSimulatorBotApp
+```
+This code works on windows. Replace the `;`s with `:`s to run it under Unix.

--- a/pom.xml
+++ b/pom.xml
@@ -1,82 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>won.bot</groupId>
-    <artifactId>randomsimulatorbot</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+	<groupId>won.bot</groupId>
+	<artifactId>randomsimulatorbot</artifactId>
+	<version>1.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-core</artifactId>
-            <version>3.5.0</version>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>jena-core</artifactId>
+			<version>3.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>at.researchstudio.sat</groupId>
+			<artifactId>won-bot</artifactId>
+			<version>0.6-SNAPSHOT</version>
+			<!-- exclusions>
+				<exclusion>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcprov-jdk15on</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcpkix-jdk15on</artifactId>
+				</exclusion>
+			</exclusions-->
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>4.3.18.RELEASE</version>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot</artifactId>
+			<version>1.5.21.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<version>1.5.21.RELEASE</version>
+		</dependency>
+		<!-- Logging with SLF4J & LogBack -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.6.6</version>
+		</dependency>
 
-        <dependency>
-            <groupId>at.researchstudio.sat</groupId>
-            <artifactId>won-bot</artifactId>
-            <version>0.6-SNAPSHOT</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot</artifactId>
-            <version>1.5.17.RELEASE</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
-        </dependency>
-        <!-- Logging with SLF4J & LogBack -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.6.6</version>
-        </dependency>
-
-    </dependencies>
-    <build>
-        <plugins>
-            <plugin>
+	</dependencies>
+	<build>
+		<finalName>won-randomsimulatorbot</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>build-bot-uberjar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>bot</finalName>
+							<shadedArtifactAttached>false</shadedArtifactAttached>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+								<excludes>
+									<!-- bouncycastle libs are signed, they cannot be included in the shaded jar -->
+									<exclude>org.bouncycastle:*</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>reference.conf</resource>
+								</transformer>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>won.bot.randomsimulatorbot.RandomSimulatorBotApp</mainClass>
+								</transformer>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>META-INF/spring.handlers</resource>
+								</transformer>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>META-INF/spring.schemas</resource>
+								</transformer>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>META-INF/spring.factories</resource>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.1.7.RELEASE</version>
-                <configuration>
-                    <mainClass>won.bot.randomsimulatorbot.RandomSimulatorBotApp</mainClass>
-                </configuration>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
                 <executions>
                     <execution>
+                        <id>copy-bouncycastle-libs</id>
+                        <!-- Some dependencies must be present in tomcat's lib folder to avoid classloader issues -->
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>repackage</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/bouncycastle-libs</outputDirectory>
+                            <includeGroupIds>org.bouncycastle</includeGroupIds>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
-    </build>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>at.researchstudio.sat</groupId>
             <artifactId>won-bot</artifactId>
-            <version>0.5-SNAPSHOT</version>
+            <version>0.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/won/bot/randomsimulatorbot/RandomSimulatorBotApp.java
+++ b/src/main/java/won/bot/randomsimulatorbot/RandomSimulatorBotApp.java
@@ -12,17 +12,23 @@ package won.bot.randomsimulatorbot;
 
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.context.annotation.PropertySource;
+
 import won.bot.framework.bot.utils.BotUtils;
+import won.bot.randomsimulatorbot.impl.RandomSimulatorBot;
 
 
-@Component
+@SpringBootConfiguration
+@PropertySource("classpath:application.properties")
+@ImportResource("classpath:/spring/app/botApp.xml")
 public class RandomSimulatorBotApp implements CommandLineRunner {
     public static void main(String[] args) throws Exception {
         if (!BotUtils.isValidRunConfig()) {
             System.exit(1);
         }
-        SpringApplication app = new SpringApplication("classpath:/spring/app/botApp.xml");
+        SpringApplication app = new SpringApplication(RandomSimulatorBotApp.class);
         app.setWebEnvironment(false);
         app.run(args);
     }

--- a/src/main/java/won/bot/randomsimulatorbot/impl/RandomSimulatorBot.java
+++ b/src/main/java/won/bot/randomsimulatorbot/impl/RandomSimulatorBot.java
@@ -139,7 +139,7 @@ public class RandomSimulatorBot extends EventBot {
                         new RandomDelayedAction(ctx, MIN_RECATION_TIMEOUT_MILLIS, MAX_REACTION_TIMEOUT_MILLIS,
                                         (long) this.hashCode(),
                                         new ProbabilisticSelectionAction(ctx, PROB_MESSAGE_ON_MESSAGE,
-                                                        (long) this.hashCode(), new SendMessageAction(ctx),
+                                                        (long) this.hashCode(), new SendMessageAction(ctx, "Test message"),
                                                         new CloseConnectionAction(ctx, "Bye!"))));
         bus.subscribe(MessageFromOtherAtomEvent.class, replyer);
         bus.subscribe(OpenFromOtherAtomEvent.class, replyer);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,11 @@
 bot.name=RandomSimulatorBot
 
+# period of new atom creation, in milliseconds
+atomCreatorBot.period=10000
+
+# where to look for TTL files that will be used as atom content
+atom.template.dir=${ATOM_TEMPLATE_DIR}
+
 # Uri of our bot (this doesn't matter much)
 won.owner.uri=https://localhost:8443/owner
 

--- a/src/main/resources/atom-templates/test-atom.ttl
+++ b/src/main/resources/atom-templates/test-atom.ttl
@@ -1,0 +1,18 @@
+@prefix p0:    <https://node.matchat.org/won/resource/atom/mlroxk7jfy68#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix chat:  <https://w3id.org/won/ext/chat#> .
+@prefix won:   <https://w3id.org/won/core#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix atom:  <https://node.matchat.org/won/resource/atom/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix hold:  <https://w3id.org/won/ext/hold#> .
+
+atom:mlroxk7jfy68  a       won:Atom ;
+        dc:title           "Test Atom" ;
+        won:defaultSocket  p0:chatSocket ;
+        won:socket         p0:chatSocket , p0:holdableSocket .
+
+p0:chatSocket  won:socketDefinition  chat:ChatSocket .
+
+p0:holdableSocket  won:socketDefinition
+                hold:HoldableSocket .

--- a/src/main/resources/atom-templates/test-atom2.ttl
+++ b/src/main/resources/atom-templates/test-atom2.ttl
@@ -1,0 +1,18 @@
+@prefix p0:    <https://node.matchat.org/won/resource/atom/mlroxk7jfy00#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix chat:  <https://w3id.org/won/ext/chat#> .
+@prefix won:   <https://w3id.org/won/core#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix atom:  <https://node.matchat.org/won/resource/atom/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+@prefix hold:  <https://w3id.org/won/ext/hold#> .
+
+atom:mlroxk7jfy00  a       won:Atom ;
+        dc:title           "Test Atom 2" ;
+        won:defaultSocket  p0:chatSocket ;
+        won:socket         p0:chatSocket , p0:holdableSocket .
+
+p0:chatSocket  won:socketDefinition  chat:ChatSocket .
+
+p0:holdableSocket  won:socketDefinition
+                hold:HoldableSocket .

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -25,6 +25,7 @@
     </appender>
 
     <logger name="won.spoco" level="DEBUG"/>
+    <logger name="won.bot.framework.eventbot.action.impl.wonmessage" level="DEBUG" />
 
     <logger name="won.bot" level="DEBUG"/>
     <logger name="won.bot.framework.bot" level="DEBUG"/>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -38,11 +38,10 @@
     <logger name="won.monitoring" level="INFO"/>
 
     <!-- START MSGTRACE: set the following to DEBUG to trace messages through the system (high level) -->
-    <logger name="won.node.protocol.impl.NeedProtocolNeedClient" level="INFO"/>
-    <logger name="won.node.protocol.impl.NeedProtocolNeedServiceImpl" level="INFO"/>
-    <logger name="won.node.protocol.impl.OwnerProtocolOwnerClient" level="INFO"/>
-    <logger name="won.owner.protocol.impl.OwnerProtocolNeedServiceClient" level="INFO"/>
-    <logger name="won.owner.messaging.OwnerProtocolOwnerServiceImpl" level="INFO"/>
+    <logger name="won.node.protocol.impl." level="INFO"/>
+    
+    <logger name="won.owner.protocol.impl" level="INFO"/>
+    <logger name="won.owner.messaging" level="INFO"/>
     <!-- END MSGTRACE -->
 
     <!-- SET to DEBUG to see bot events -->

--- a/src/main/resources/spring/bot/bot.xml
+++ b/src/main/resources/spring/bot/bot.xml
@@ -1,48 +1,64 @@
-<!--
-  ~ Copyright 2012  Research Studios Austria Forschungsges.m.b.H.
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- ~ Copyright 2012 Research Studios Austria Forschungsges.m.b.H. ~ ~ Licensed 
+	under the Apache License, Version 2.0 (the "License"); ~ you may not use 
+	this file except in compliance with the License. ~ You may obtain a copy 
+	of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless 
+	required by applicable law or agreed to in writing, software ~ distributed 
+	under the License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES 
+	OR CONDITIONS OF ANY KIND, either express or implied. ~ See the License for 
+	the specific language governing permissions and ~ limitations under the License. -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <import resource="classpath:/spring/component/atomproducer/atomproducer-mixed.xml"/>
+	<import
+		resource="classpath:/spring/component/atomproducer/atomproducer-mixed.xml" />
 
-    <bean id="atomCreatorBot" class="won.bot.randomsimulatorbot.impl.RandomSimulatorBot">
-        <property name="taskScheduler" ref="taskScheduler"/>
-        <property name="botContextWrapper" ref="botContextWrapper"/>
-        <property name="atomProducer" ref="atomProducerMixed"/>
-        <property name="nodeURISource" ref="nodeUriSourceRandom"/>
-        <property name="wonMessageSender" ref="ownerProtocolAtomServiceClientJMSBased"/>
-        <property name="trigger">
-            <bean class="org.springframework.scheduling.support.PeriodicTrigger">
-                <constructor-arg name="period" value="${atomCreatorBot.period}"/>
-                <constructor-arg name="timeUnit" value="MILLISECONDS"/>
-                <property name="initialDelay" value="10000"/> <!-- wait 10s at the beginning -->
-                <property name="fixedRate" value="true"/>  <!-- fixed delay after completion -->
-            </bean>
-        </property>
-    </bean>
+	<bean id="atomCreatorBot"
+		class="won.bot.randomsimulatorbot.impl.RandomSimulatorBot">
+		<property name="taskScheduler" ref="taskScheduler" />
+		<property name="botContextWrapper" ref="botContextWrapper" />
+		<property name="atomProducer" ref="myAtomProducer" />
+		<property name="nodeURISource" ref="nodeUriSourceRandom" />
+		<property name="wonMessageSender"
+			ref="ownerProtocolAtomServiceClientJMSBased" />
+		<property name="trigger">
+			<bean
+				class="org.springframework.scheduling.support.PeriodicTrigger">
+				<constructor-arg name="period"
+					value="${atomCreatorBot.period}" />
+				<constructor-arg name="timeUnit"
+					value="MILLISECONDS" />
+				<property name="initialDelay" value="10000" /> <!-- wait 10s at the beginning -->
+				<property name="fixedRate" value="true" />  <!-- fixed delay after completion -->
+			</bean>
+		</property>
+	</bean>
 
-    <bean id="botContextWrapper" class="won.bot.framework.bot.context.BotContextWrapper">
-        <constructor-arg name="botContext" ref="${botContext.impl}"/>
-        <constructor-arg name="botName" value="${bot.name}"/>
-    </bean>
+	<bean id="botContextWrapper"
+		class="won.bot.framework.bot.context.BotContextWrapper">
+		<constructor-arg name="botContext"
+			ref="${botContext.impl}" />
+		<constructor-arg name="botName" value="${bot.name}" />
+	</bean>
 
-    <bean id="nodeUriSourceRandom" class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource">
-        <property name="nodeURIs" value="#{'${won.node.uris}'.split(' ')}"/>
-    </bean>
+	<bean id="nodeUriSourceRandom"
+		class="won.bot.framework.component.nodeurisource.impl.RandomMultiNodeUriSource">
+		<property name="nodeURIs"
+			value="#{'${won.node.uris}'.split(' ')}" />
+	</bean>
+
+	<bean id="myAtomProducer"
+		class="won.bot.framework.component.atomproducer.impl.DirectoryBasedAtomProducer">
+		<property name="directory" value="${atom.template.dir}" />
+		<property name="filenameFilterRegex" value=".*ttl" />
+		<property name="repeat" value="true" />
+		<property name="fileBasedAtomProducer">
+			<bean
+				class="won.bot.framework.component.atomproducer.impl.TurtleFileAtomProducer">
+			</bean>
+		</property>
+	</bean>
+
 </beans>


### PR DESCRIPTION
The steps in the README.md should work. 
There is the issue of the bouncycastle libs that hasn't popped up with the other bots, but here it has. Solved it the same way as with the won-rdfimport-bot, i.e., add the maven dependency plugin to pull the two required libs into the target folder and explain how to add them to the classpath in the README.